### PR TITLE
Added VoidCallback to call onTap

### DIFF
--- a/lib/pie_timer.dart
+++ b/lib/pie_timer.dart
@@ -83,7 +83,7 @@ class PieTimer extends StatefulWidget {
 
 class _PieTimerState extends State<PieTimer>
     with SingleTickerProviderStateMixin {
-  late AnimationController _controller;
+  late PieAnimationController _controller;
 
   late Animation<double> _pieAnimation;
   late Animation<Duration> _timerAnimation;
@@ -109,13 +109,15 @@ class _PieTimerState extends State<PieTimer>
     // If animation controller is null, set AnimationController,
     // If not, initialize pieAnimationController as AnimationController.
     if (widget.pieAnimationController != null) {
-      _controller = widget.pieAnimationController as AnimationController
+      _controller = widget.pieAnimationController as PieAnimationController
         ..duration = widget.duration;
+      _controller.onTap = () => _onTap();
     } else {
-      _controller = AnimationController(
+      _controller = PieAnimationController(
         vsync: this,
-        duration: widget.duration,
       );
+      _controller.duration = widget.duration;
+      _controller.onTap = () => _onTap();
     }
 
     _controller.addStatusListener((status) {
@@ -388,5 +390,9 @@ class TimePainter extends CustomPainter {
 
 /// If you want to use PieAnimationController, do it inside the state of a statful widget with Ticker.
 class PieAnimationController extends AnimationController {
+  
+  /// Function callback to call _onTap() from outisde context code. (Exemple InkWell)
+  VoidCallback? onTap;
+
   PieAnimationController({required super.vsync});
 }


### PR DESCRIPTION
This small patch allows the original _onTap method to be called via the PieAnimationController. Because of this I can use a container/button/other to hide or display the pause icon. 

I noticed that the pause icon shows only when pressing on the timer but if I want to display the icon by pressing on another space the icon does not feel any change. If the icon was visible the icon will remain visible even if I restart the timer externally. 

I am not an expert on Flutter but I hope this system is a good patch. I hope I have made the idea of the problem.  If the code does not fit the flutter standards, I will make another issue to let you update the code.

## Issue
```dart
onTap: () => {
            if(pieControllers[timerIndex].isAnimating)
            {
              pieControllers[timerIndex].stop()
            }
            else
            {
              pieControllers[timerIndex].forward()
            }
          },
```
https://user-images.githubusercontent.com/62484597/190103357-e3c33562-2f33-4c25-9735-a7c000479fa3.mp4

## Fix
```dart
 InkWell(
          onTap: () => {
            pieControllers[timerIndex].onTap?.call()
          },
```

https://user-images.githubusercontent.com/62484597/190103691-cd7a9c95-72ed-43f4-858e-ffa3ff3dba51.mp4


